### PR TITLE
Revisit RNS

### DIFF
--- a/src/circuit/ecc/general_ecc.rs
+++ b/src/circuit/ecc/general_ecc.rs
@@ -194,13 +194,13 @@ impl<Emulated: CurveAffine, N: FieldExt> GeneralEccInstruction<Emulated, N> for 
 #[cfg(test)]
 mod tests {
     use crate::circuit::ecc::general_ecc::{GeneralEccChip, GeneralEccInstruction};
-    use crate::circuit::ecc::{AssignedPoint, EccConfig, Point};
+    use crate::circuit::ecc::{AssignedPoint, EccConfig};
     use crate::circuit::integer::{IntegerChip, IntegerConfig, IntegerInstructions};
     use crate::circuit::main_gate::{MainGate, MainGateConfig, MainGateInstructions};
     use crate::circuit::range::{RangeChip, RangeConfig, RangeInstructions};
-    use crate::rns::{Integer, Limb, Rns};
-    use group::{prime::PrimeCurveAffine, Curve};
-    use halo2::arithmetic::{CurveAffine, Field, FieldExt};
+    use crate::rns::Rns;
+    use group::prime::PrimeCurveAffine;
+    use halo2::arithmetic::{CurveAffine, FieldExt};
     use halo2::circuit::{Layouter, SimpleFloorPlanner};
     use halo2::dev::MockProver;
     use halo2::plonk::{Circuit, ConstraintSystem, Error};
@@ -306,7 +306,7 @@ mod tests {
     }
 
     fn test_ecc_add_circuit(a: Option<u64>, b: Option<u64>, c: Option<u64>) {
-        let bit_len_limb = 64;
+        let bit_len_limb = 68;
 
         let rns_base = Rns::<<C as CurveAffine>::Base, Native>::construct(bit_len_limb);
         let rns_scalar = Rns::<<C as CurveAffine>::ScalarExt, Native>::construct(bit_len_limb);

--- a/src/circuit/integer/add.rs
+++ b/src/circuit/integer/add.rs
@@ -29,7 +29,7 @@ impl<W: FieldExt, N: FieldExt> IntegerChip<W, N> {
         }
         let c_native = main_gate.add(region, a.native(), b.native(), offset)?;
 
-        Ok(AssignedInteger::new(c_limbs, c_native))
+        Ok(self.new_assigned_integer(c_limbs, c_native))
     }
 
     pub(crate) fn _add_constant(
@@ -53,6 +53,6 @@ impl<W: FieldExt, N: FieldExt> IntegerChip<W, N> {
         }
         let c_native = main_gate.add_constant(region, a.native(), b.native(), offset)?;
 
-        Ok(AssignedInteger::new(c_limbs, c_native))
+        Ok(self.new_assigned_integer(c_limbs, c_native))
     }
 }

--- a/src/circuit/integer/assert_not_zero.rs
+++ b/src/circuit/integer/assert_not_zero.rs
@@ -1,7 +1,6 @@
 use super::IntegerChip;
 use crate::circuit::main_gate::{CombinationOption, MainGateInstructions, Term};
 use crate::circuit::{AssignedInteger, AssignedValue};
-use crate::BIT_LEN_LIMB;
 use halo2::arithmetic::FieldExt;
 use halo2::circuit::Region;
 use halo2::plonk::Error;
@@ -18,8 +17,8 @@ impl<W: FieldExt, N: FieldExt> IntegerChip<W, N> {
         let r = self._reduce(region, a, offset)?;
 
         // Sanity check.
-        // This algorithm requires that wrong modulus * 2 <= native modulus * 2 ^ BIT_LEN_LIMB.
-        let two_pow_limb_bits_minus_1 = big_uint::from(2u64).pow((BIT_LEN_LIMB - 1).try_into().unwrap());
+        // This algorithm requires that wrong modulus * 2 <= native modulus * 2 ^ bit_len_limb.
+        let two_pow_limb_bits_minus_1 = big_uint::from(2u64).pow((self.rns.bit_len_limb - 1).try_into().unwrap());
         assert!(self.rns.wrong_modulus.clone() <= self.rns.native_modulus.clone() * two_pow_limb_bits_minus_1);
 
         // r = 0 <-> r % 2 ^ 64 = 0 /\ r % native_modulus = 0

--- a/src/circuit/integer/assert_zero.rs
+++ b/src/circuit/integer/assert_zero.rs
@@ -28,9 +28,9 @@ impl<W: FieldExt, N: FieldExt> IntegerChip<W, N> {
     pub(crate) fn _assert_zero(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, offset: &mut usize) -> Result<(), Error> {
         let main_gate = self.main_gate();
         let (zero, one) = (N::zero(), N::one());
-        let negative_wrong_modulus: Vec<N> = self.rns.negative_wrong_modulus.clone();
+        let negative_wrong_modulus: Vec<N> = self.rns.negative_wrong_modulus_decomposed.clone();
 
-        let reduction_result = a.integer().map(|integer_a| {
+        let reduction_result = a.integer(self.rns.bit_len_limb).map(|integer_a| {
             let reduction_result = self.rns.reduce(&integer_a);
 
             assert_eq!(reduction_result.result.value(), big_uint::zero());

--- a/src/circuit/integer/sub.rs
+++ b/src/circuit/integer/sub.rs
@@ -33,6 +33,6 @@ impl<W: FieldExt, N: FieldExt> IntegerChip<W, N> {
 
         let c_native = main_gate.sub_with_constant(region, a.native(), b.native(), aux_native, offset)?;
 
-        Ok(AssignedInteger::new(c_limbs, c_native))
+        Ok(self.new_assigned_integer(c_limbs, c_native))
     }
 }

--- a/src/circuit/range.rs
+++ b/src/circuit/range.rs
@@ -270,6 +270,11 @@ impl<F: FieldExt> RangeChip<F> {
     }
 
     pub fn configure(meta: &mut ConstraintSystem<F>, main_gate_config: &MainGateConfig, fine_tune_bit_lengths: Vec<usize>) -> RangeConfig {
+        let mut fine_tune_bit_lengths = fine_tune_bit_lengths.clone();
+        fine_tune_bit_lengths.sort();
+        fine_tune_bit_lengths.dedup();
+        let fine_tune_bit_lengths: Vec<usize> = fine_tune_bit_lengths.into_iter().filter(|e| *e != 0).collect();
+
         let a = main_gate_config.a;
         let b = main_gate_config.b;
         let c = main_gate_config.c;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 mod circuit;
 mod rns;
 
-pub(crate) const BIT_LEN_LIMB: usize = 64;
 pub(crate) const NUMBER_OF_LIMBS: usize = 4;
 pub(crate) const NUMBER_OF_LOOKUP_LIMBS: usize = 4;


### PR DESCRIPTION
This PR

* Revisits RNS
  * Covers `v_x` bits sizes in construction time
  * Calculates boundaries of max integers and limbs
* Adds ranging integers functionlity by it's context such as remainder of multiplication or quotient value
* Introduces `reduce_if_necessary` function to enable lazy additions